### PR TITLE
Fixed missing image URL by adding placeholder.png to render if the im…

### DIFF
--- a/frontend/src/components/Item/index.js
+++ b/frontend/src/components/Item/index.js
@@ -50,7 +50,7 @@ class Item extends React.Component {
           <div className="row bg-white p-4">
             <div className="col-6">
               <img
-                src={this.props.item.image}
+                src={this.props.item.image ||"../placeholder.png"}
                 alt={this.props.item.title}
                 className="item-img"
                 style={{ height: "500px", width: "100%", borderRadius: "6px" }}

--- a/frontend/src/components/Item/index.js
+++ b/frontend/src/components/Item/index.js
@@ -50,7 +50,7 @@ class Item extends React.Component {
           <div className="row bg-white p-4">
             <div className="col-6">
               <img
-                src={this.props.item.image ||"../placeholder.png"}
+                src={this.props.item.image || "../placeholder.png"}
                 alt={this.props.item.title}
                 className="item-img"
                 style={{ height: "500px", width: "100%", borderRadius: "6px" }}

--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -36,7 +36,7 @@ const ItemPreview = (props) => {
     >
       <img
         alt="item"
-        src={item.image}
+        src={item.image || "placeholder.png"}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
       />


### PR DESCRIPTION
…age URL field is blank.

# Description
Addresses #2 
<img width="1139" alt="Screen Shot 2022-07-26 at 4 04 27 PM" src="https://user-images.githubusercontent.com/2799105/181103560-99ca5394-bd68-4de0-a037-0f51f2232705.png">
<img width="1313" alt="Screen Shot 2022-07-26 at 4 04 42 PM" src="https://user-images.githubusercontent.com/2799105/181103563-3afacde6-157f-4fbd-a379-d40bb1826ace.png">

